### PR TITLE
changed custom lcm function to use R built-in Reduce function

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -77,11 +77,11 @@ fraction <- function(x, d, verbose = FALSE) {
 # Uses rational tuning system 2
 # Non-integer inputs permitted
 # @param d = 0.011 corresponds to rational tuning 2
-get_rational_interval <- function(x, d) {
+get_rational_interval <- function(x, d = 0.011) {
   stopifnot(length(x) == 1L)
   octave <- floor(x / 12)
   pitch_class <- x %% 12
-  res <- fraction(2 ^ (pitch_class / 12), d = 0.011)
+  res <- fraction(2 ^ (pitch_class / 12), d = d)
   while (octave != 0) {
     if (octave < 0) {
       res <- half_fraction(res)
@@ -115,8 +115,4 @@ relative_periodicity <- function(x) {
   lcm(x[2, ])  * x[1, 1] / x[2, 1]
 }
 
-lcm <- function(x) {
-  if (length(x) == 1L) x else if (length(x) == 2L) {
-    gmp::lcm.default(x[1], x[2])
-  } else lcm(c(x[1], lcm(x[-1])))
-}
+lcm <- function(x) Reduce(numbers::LCM, x)

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -48,3 +48,18 @@ test_that("smooth_log_periodicity", {
   expect_equal(smooth_log_periodicity(c(0, 3, 7)), log2(10))
   expect_equal(smooth_log_periodicity(c(0:11)) %>% round(digits = 1), 7.4)
 })
+
+test_that('changing deviation works', {
+  default_d = smooth_log_periodicity(c(60, 61.1))
+  custom_d  = smooth_log_periodicity(c(60, 61.1), d=0.05)
+  expect_true(default_d != custom_d)
+})
+
+test_that('results are not NaN for 10 harmonics',{
+  from_timbre_paper = smooth_log_periodicity(
+    c(60, 64.41441, 72.84467, 77.25909, 80.35832, 84.77274, 85.68934, 89.82440,
+      90.10376, 93.20300, 94.23882, 96.05955, 97.61741, 98.53402, 100.47397,
+      100.71665, 102.66908, 102.94843)
+  )
+  expect_false(is.nan(from_timbre_paper))
+})


### PR DESCRIPTION
Stolzenberg 2015 was giving NaNs for some stretched chords with 10 harmonics. Replaced the custom, recursive lcm code with R's built-in Reduce function. Fixes #3. No more NaNs.